### PR TITLE
Add observers to replace text in added/modified nodes

### DIFF
--- a/Source/content_script.js
+++ b/Source/content_script.js
@@ -2,30 +2,20 @@ walk(document.body);
 
 document.title = replaceText(document.title);
 
-function walk(node)
+function walk(rootNode)
 {
-	// I stole this function from here:
-	// http://is.gd/mwZp7E
+	// Find all the text nodes in rootNode
+	var walker = document.createTreeWalker(
+		rootNode,
+		NodeFilter.SHOW_TEXT,
+		null,
+		false
+	),
+	node;
 
-	var child, next;
-
-	switch ( node.nodeType )
-	{
-		case 1:  // Element
-		case 9:  // Document
-		case 11: // Document fragment
-			child = node.firstChild;
-			while ( child )
-			{
-				next = child.nextSibling;
-				walk(child);
-				child = next;
-			}
-			break;
-
-		case 3: // Text node
-			handleText(node);
-			break;
+	// Modify each text node's value
+	while (node = walker.nextNode()) {
+		handleText(node);
 	}
 }
 

--- a/Source/content_script.js
+++ b/Source/content_script.js
@@ -1,7 +1,3 @@
-walk(document.body);
-
-document.title = replaceText(document.title);
-
 function walk(rootNode)
 {
 	// Find all the text nodes in rootNode
@@ -184,3 +180,7 @@ function replaceText(v)
 
 	return v;
 }
+
+// Replace text in the document body and title
+walk(document.body);
+document.title = replaceText(document.title);

--- a/Source/content_script.js
+++ b/Source/content_script.js
@@ -1,5 +1,5 @@
 var documentTitle = document.getElementsByTagName('title')[0],
-	mutationConfig = {
+	observerConfig = {
 		characterData: true,
 		childList: true,
 		subtree: true
@@ -212,8 +212,8 @@ document.title = replaceText(document.title);
 
 // Observe the body so that we replace text in any added/modified nodes
 bodyObserver = new MutationObserver(observerCallback);
-bodyObserver.observe(document.body, mutationConfig);
+bodyObserver.observe(document.body, observerConfig);
 
 // Observe the title so we can handle any modifications there
 titleObserver = new MutationObserver(observerCallback);
-titleObserver.observe(documentTitle, mutationConfig);
+titleObserver.observe(documentTitle, observerConfig);

--- a/Source/content_script.js
+++ b/Source/content_script.js
@@ -1,3 +1,11 @@
+var documentTitle = document.getElementsByTagName('title')[0],
+	mutationConfig = {
+		characterData: true,
+		childList: true,
+		subtree: true
+	},
+	bodyObserver, titleObserver;
+
 function walk(rootNode)
 {
 	// Find all the text nodes in rootNode
@@ -181,6 +189,31 @@ function replaceText(v)
 	return v;
 }
 
-// Replace text in the document body and title
+// The callback used for the document body and title observers
+function observerCallback(mutations) {
+	var i;
+
+	mutations.forEach(function(mutation) {
+		for (i = 0; i < mutation.addedNodes.length; i++) {
+			if (mutation.addedNodes[i].nodeType === 3) {
+				// Replace the text for text nodes
+				handleText(mutation.addedNodes[i]);
+			} else {
+				// Otherwise, find text nodes within the given node and replace text
+				walk(mutation.addedNodes[i]);
+			}
+		}
+	});
+}
+
+// Do the inital text replacements in the document body and title
 walk(document.body);
 document.title = replaceText(document.title);
+
+// Observe the body so that we replace text in any added/modified nodes
+bodyObserver = new MutationObserver(observerCallback);
+bodyObserver.observe(document.body, mutationConfig);
+
+// Observe the title so we can handle any modifications there
+titleObserver = new MutationObserver(observerCallback);
+titleObserver.observe(documentTitle, mutationConfig);


### PR DESCRIPTION
A number of people have commented saying the extension doesn't replace _all_ text and this is partly because dynamic content isn't handled. Right now the extension simply replaces text after the page is loaded, so we don't handle anything that's not present at that point.

To help fix this, I've added observers that watch for modifications in document.body and document.title and replace text appropriately.  [I'm working on handling same-origin iframes as well, so that will be forthcoming.]
