### PR TITLE
Replace text in iframes and observe iframe document

### DIFF
--- a/Source/content_script.js
+++ b/Source/content_script.js
@@ -2,30 +2,20 @@ walk(document.body);
 
 document.title = replaceText(document.title);
 
-function walk(node)
+function walk(rootNode)
 {
-	// I stole this function from here:
-	// http://is.gd/mwZp7E
+	// Find all the text nodes in rootNode
+	var walker = document.createTreeWalker(
+		rootNode,
+		NodeFilter.SHOW_TEXT,
+		null,
+		false
+	),
+	node;
 
-	var child, next;
-
-	switch ( node.nodeType )
-	{
-		case 1:  // Element
-		case 9:  // Document
-		case 11: // Document fragment
-			child = node.firstChild;
-			while ( child )
-			{
-				next = child.nextSibling;
-				walk(child);
-				child = next;
-			}
-			break;
-
-		case 3: // Text node
-			handleText(node);
-			break;
+	// Modify each text node's value
+	while (node = walker.nextNode()) {
+		handleText(node);
 	}
 }
 

--- a/Source/content_script.js
+++ b/Source/content_script.js
@@ -1,7 +1,3 @@
-walk(document.body);
-
-document.title = replaceText(document.title);
-
 function walk(rootNode)
 {
 	// Find all the text nodes in rootNode
@@ -184,3 +180,7 @@ function replaceText(v)
 
 	return v;
 }
+
+// Replace text in the document body and title
+walk(document.body);
+document.title = replaceText(document.title);

--- a/Source/content_script.js
+++ b/Source/content_script.js
@@ -1,5 +1,3 @@
-var iframes, i;
-
 function walk(rootNode)
 {
 	// Find all the text nodes in rootNode
@@ -226,12 +224,3 @@ function walkAndObserve(doc) {
 	}
 }
 walkAndObserve(document);
-
-// Collect the iframes and replace text in each like we do with the document
-iframes = document.getElementsByTagName('iframe');
-for (i = 0; i < iframes.length; i++) {
-	if (iframes[i].src.match('^https?://' + document.domain)) {
-		// Walk and observe the iframe if it's the same origin as the page
-		walkAndObserve(iframes[i].contentWindow.document);
-	}
-}

--- a/Source/content_script.js
+++ b/Source/content_script.js
@@ -1,5 +1,5 @@
 var documentTitle = document.getElementsByTagName('title')[0],
-	mutationConfig = {
+	observerConfig = {
 		characterData: true,
 		childList: true,
 		subtree: true
@@ -212,8 +212,8 @@ document.title = replaceText(document.title);
 
 // Observe the body so that we replace text in any added/modified nodes
 bodyObserver = new MutationObserver(observerCallback);
-bodyObserver.observe(document.body, mutationConfig);
+bodyObserver.observe(document.body, observerConfig);
 
 // Observe the title so we can handle any modifications there
 titleObserver = new MutationObserver(observerCallback);
-titleObserver.observe(documentTitle, mutationConfig);
+titleObserver.observe(documentTitle, observerConfig);

--- a/Source/content_script.js
+++ b/Source/content_script.js
@@ -1,3 +1,11 @@
+var documentTitle = document.getElementsByTagName('title')[0],
+	mutationConfig = {
+		characterData: true,
+		childList: true,
+		subtree: true
+	},
+	bodyObserver, titleObserver;
+
 function walk(rootNode)
 {
 	// Find all the text nodes in rootNode
@@ -181,6 +189,31 @@ function replaceText(v)
 	return v;
 }
 
-// Replace text in the document body and title
+// The callback used for the document body and title observers
+function observerCallback(mutations) {
+	var i;
+
+	mutations.forEach(function(mutation) {
+		for (i = 0; i < mutation.addedNodes.length; i++) {
+			if (mutation.addedNodes[i].nodeType === 3) {
+				// Replace the text for text nodes
+				handleText(mutation.addedNodes[i]);
+			} else {
+				// Otherwise, find text nodes within the given node and replace text
+				walk(mutation.addedNodes[i]);
+			}
+		}
+	});
+}
+
+// Do the inital text replacements in the document body and title
 walk(document.body);
 document.title = replaceText(document.title);
+
+// Observe the body so that we replace text in any added/modified nodes
+bodyObserver = new MutationObserver(observerCallback);
+bodyObserver.observe(document.body, mutationConfig);
+
+// Observe the title so we can handle any modifications there
+titleObserver = new MutationObserver(observerCallback);
+titleObserver.observe(documentTitle, mutationConfig);

--- a/Source/manifest.json
+++ b/Source/manifest.json
@@ -18,6 +18,7 @@
 	[
 		{
 			"matches": ["*://*/*"],
+			"all_frames": true,
 			"js": ["content_script.js"],
 			"run_at": "document_end"
 		}


### PR DESCRIPTION
This takes care of replacing text in iframes and observing an iframe's document body and title (like we do with the page document). This commit also refactors the previous walk and observe statements that we used on the page document into a reusable function.
