### PR TITLE
Remove unnecessary ? from millennialism regex

### DIFF
--- a/Source/content_script.js
+++ b/Source/content_script.js
@@ -38,8 +38,8 @@ function replaceText(v)
     );
 
     // Millennialism
-    v = v.replace(/\bMillennialism?\b/g, "Reptilianism");
-    v = v.replace(/\bmillennialism?\b/g, "reptilianism");
+    v = v.replace(/\bMillennialism\b/g, "Reptilianism");
+    v = v.replace(/\bmillennialism\b/g, "reptilianism");
 
 
     //  Gendered Millennials


### PR DESCRIPTION
This was matching both "millennialis" and "millennialism" and I believe we're just looking to match "millennialism", so we can just remove the question mark after the last m (since it's not really optional).
