### PR TITLE
Fixed Facebook comment replacement and exclude GitHub page from replace

### DIFF
--- a/Source/content_script.js
+++ b/Source/content_script.js
@@ -1,10 +1,16 @@
 function walk(rootNode)
 {
+	myfilter = function(node) {
+		if (left(node.ID, 11) == "add_comment") // facebook comments input
+			return NodeFilter.FILTER_ACCEPT
+		else
+			return NodeFilter.FILTER_SKIP
+	}
     // Find all the text nodes in rootNode
     var walker = document.createTreeWalker(
         rootNode,
         NodeFilter.SHOW_TEXT,
-        null,
+        myfilter,
         false
     ),
     node;

--- a/Source/manifest.json
+++ b/Source/manifest.json
@@ -18,7 +18,7 @@
 	[
 		{
 			"matches": ["*://*/*"],
-			"exclude_matches": ["*://*github*millennials-to-snake-people*"],
+			"exclude_matches": ["*://*/*millennials-to-snake-people*"],
 			"all_frames": true,
 			"js": ["content_script.js"],
 			"run_at": "document_end"

--- a/Source/manifest.json
+++ b/Source/manifest.json
@@ -18,7 +18,7 @@
 	[
 		{
 			"matches": ["*://*/*"],
-			"exclude_matches": ["*://*/*millennials-to-snake-people*"],
+			"exclude_matches": ["*://*github*millennials-to-snake-people*"],
 			"all_frames": true,
 			"js": ["content_script.js"],
 			"run_at": "document_end"

--- a/Source/manifest.json
+++ b/Source/manifest.json
@@ -2,7 +2,7 @@
 	"manifest_version": 2,
 
 	"name": "Millennials to Snake People",
-    "short_name": "Snake People",
+    	"short_name": "Snake People",
 	"description": "Replaces the text 'Millennial' with 'Snake People'.",
 	"author": "Eric Bailey",
 	"version": "1.7",
@@ -18,6 +18,7 @@
 	[
 		{
 			"matches": ["*://*/*"],
+			"exclude_matches": ["*://*/*millennials-to-snake-people*"],
 			"all_frames": true,
 			"js": ["content_script.js"],
 			"run_at": "document_end"


### PR DESCRIPTION
Added a filter to prevent replacement in facebook comments.

also excluded replacement on github pages so that you can see the replaced values without disabling the extension.
