### PR TITLE
Stop changing input text

### DIFF
--- a/Source/content_script.js
+++ b/Source/content_script.js
@@ -246,7 +246,7 @@ function observerCallback(mutations) {
 
     mutations.forEach(function(mutation) {
         for (i = 0; i < mutation.addedNodes.length; i++) {
-            if (mutation.addedNodes[i].nodeType === 3) {
+            if (mutation.addedNodes[i].nodeType === 3 && nutation.addedNodes[i].parentElement.tagName.match(/(input|textarea)/i)) {
                 // Replace the text for text nodes
                 handleText(mutation.addedNodes[i]);
             } else {


### PR DESCRIPTION
As referenced in #21 changing millennials in textareas and input methods is problematic not just because the cursor jumps around, but you really do need to sometimes type millennials or read it in a form, no matter how dirty it may sound. 

My PR ignores mutations that are text input and textarea based. It seems to work with DraftJS from my testing.