### PR TITLE
Do not replace 'tween

### DIFF
--- a/Source/content_script.js
+++ b/Source/content_script.js
@@ -134,8 +134,8 @@ function replaceText(v)
 
     // tweens
     // The replacement syntax here emulates a negative lookbehind to avoid replacing `'tween`
-    v = v.replace( /(')?\bTween/g, function ($0, $1) { return ($1 ? $0 : "Neonate") });
-    v = v.replace( /(')?\btween/g, function ($0, $1) { return ($1 ? $0 : "neonate") });
+    v = v.replace( /(')?\bTween(s)?\b/g, function ($0, $1, $2) { return ($1 ? $0 : $2 ? "Neonates" : "Neonate") });
+    v = v.replace( /(')?\btween(s)?\b/g, function ($0, $1, $2) { return ($1 ? $0 : $2 ? "neonates" : "neonate") });
 
 
     // Generation Y

--- a/Source/content_script.js
+++ b/Source/content_script.js
@@ -133,8 +133,10 @@ function replaceText(v)
     v = v.replace(/\bz generation\b/g, "children of the Zolom");
 
     // tweens
-    v = v.replace(/\bTween(s)?\b/g, "Neonate$1");
-    v = v.replace(/\btween(s)?\b/g, "neonate$1");
+    // The replacement syntax here emulates a negative lookbehind to avoid replacing `'tween`
+    v = v.replace( /(')?\bTween/g, function ($0, $1) { return ($1 ? $0 : "Neonate") });
+    v = v.replace( /(')?\btween/g, function ($0, $1) { return ($1 ? $0 : "neonate") });
+
 
     // Generation Y
     v = v.replace(/\b(?:Generation Y)|(?:Generation Why)\b/g,


### PR DESCRIPTION
'Tween is incorrectly replaced. Doesn't affect most text on the web, but I recently read a short story with a character from the American South, and it got pretty butchered.

This patch uses a technique I ~~stole~~borrowed from [this post](http://stackoverflow.com/a/35143111/432690) on SE. It uses a clever regex to capture the `'` and change the replacement output depending on whether it was detected.

I used the following as my test suite and it properly handles them all:
```
tween
tweens
between
tweener
trouble 'tween the two
Those tweens are ruining everything
```
If you have any questions or comments, fire away.