### PR TITLE
Add checks to avoid replacing user-editable content. Fixes #21, #13

### DIFF
--- a/Source/content_script.js
+++ b/Source/content_script.js
@@ -240,18 +240,30 @@ function replaceText(v)
     return v;
 }
 
+// Returns true if a node should *not* be altered in any way
+function isForbiddenNode(node) {
+    return node.isContentEditable || // DraftJS and many others
+    (node.parentNode && node.parentNode.isContentEditable) || // Special case for Gmail
+    (node.tagName && (node.tagName.toLowerCase() == "textarea" || // Some catch-alls
+                     node.tagName.toLowerCase() == "input"));
+}
+
 // The callback used for the document body and title observers
 function observerCallback(mutations) {
-    var i;
+    var i, node;
 
     mutations.forEach(function(mutation) {
         for (i = 0; i < mutation.addedNodes.length; i++) {
-            if (mutation.addedNodes[i].nodeType === 3) {
+            node = mutation.addedNodes[i];
+            if (isForbiddenNode(node)) {
+                // Should never operate on user-editable content
+                continue;
+            } else if (node.nodeType === 3) {
                 // Replace the text for text nodes
-                handleText(mutation.addedNodes[i]);
+                handleText(node);
             } else {
                 // Otherwise, find text nodes within the given node and replace text
-                walk(mutation.addedNodes[i]);
+                walk(node);
             }
         }
     });


### PR DESCRIPTION
This checks if the mutated node (or its parent) has the `contenteditable` attribute (fixes cursor issues with DraftJS/Gmail a la #21), or is a `textarea` or `input` field (following #22 in an extensible way, and should address some of #13)

This seems to fix all issues with Facebook/DraftJS, but doesn't catch every corner for Gmail. In particular, typing "millenial" in the `To` field will still trigger a replacement (I'm not clear if this actually affects the recipient or is strictly cosmetic). However, the body of the message and the subject should be unaffected by the extension.