### PR TITLE
It's all about The Great Ape-Snake War

### DIFF
--- a/Source/content_script.js
+++ b/Source/content_script.js
@@ -104,12 +104,8 @@ function replaceText(v)
 
     // Occupy Wall Street
     v = v.replace(
-        /\b(?:(?:Occupy|OWS) (?:M|m)ovement)|(?:Occupy Wall Street)\b/g,
-        "Great Ape-Snake War"
-    );
-    v = v.replace(
-        /\b(?:(?:occupy|OWS|ows) movement)|(?:occupy wall street)\b/g,
-        "great ape-snake war"
+        /\b(?:the )?(?:(?:(?:occupy|ows) movement)|(?:occupy wall (?:street|st\.?)(?: movement)?))(?!\w)/gi,
+        "The Great Ape-Snake War"
     );
     v = v.replace(/\bOWS\b/g, "GA-SW");
     v = v.replace(/\bows\b/g, "ga-sw");


### PR DESCRIPTION
Made a few changes to the Great Ape-Snake War replacement:

1. Added "The" to the replacement: "The Great Ape-Snake War" (this makes more sense in almost any context)
    - However, it won't double "the" if there already is one; "The Great Ape-Snake War" will still be replaced with "The Great Ape-Snake War"
2. Made this particular replacement case-insensitive because there are too many feasible combinations of case for these words
3. Added allowance for "Great Ape-Snake War Movement" (before it could only match "Great Ape-Snake War" or "Great Ape-Snake War"
4. Added allowance for abbreviating "Street" to "St." (or "St")
    - For this to work, I had to replace the word boundary at the end (`\b`) with a negative lookahead (`(?!\w)`), or else it wouldn't be able to match the period in "St."
