### PR TITLE
Ssssssupport for Gen Z, gen-Z, and related

### DIFF
--- a/Source/content_script.js
+++ b/Source/content_script.js
@@ -123,8 +123,8 @@ function replaceText(v)
     v = v.replace(/\bdigital native(s)?\b/g, "parseltongue$1");
 
     // Generation Z
-    v = v.replace(/\bGeneration Z\b/g, "The Zolom's Children");
-    v = v.replace(/\bgeneration Z\b/g, "the Zolom's children");
+    v = v.replace(/\bGen(?:eration|-)? ?Z\b/g, "The Zolom's Children");
+    v = v.replace(/\bgen(?:eration|-)? ?(?i)Z\b/g, "the Zolom's children");
     v = v.replace(/\bZ Generation\b/g, "Children of the Zolom");
     v = v.replace(/\bz generation\b/g, "children of the Zolom");
 


### PR DESCRIPTION
This PR addresses #29 to make sure Gen Z, etc. are corrected properly. 

This should replace Generation Z, Gen Z, Gen-Z, and their lowercase versions with "The Zolom's Children". For the lowercase version, I made the "Z" case-insensitive since either "gen Z" or "gen z" could be reasonably expected. 